### PR TITLE
PJ-04: Add environment variable support and update .gitignore

### DIFF
--- a/thermal_app/.env.example
+++ b/thermal_app/.env.example
@@ -1,0 +1,3 @@
+# Substitua pelos valores reais do seu canal ThingSpeak
+CHANNEL_ID=YOUR_CHANNEL_ID
+API_KEY=YOUR_API_KEY

--- a/thermal_app/.gitignore
+++ b/thermal_app/.gitignore
@@ -42,3 +42,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Environment variables file
+.env

--- a/thermal_app/lib/main.dart
+++ b/thermal_app/lib/main.dart
@@ -1,7 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'screens/dashboard_screen.dart';
 
-void main() {
+Future<void> main() async {
+  // Load environment variables from the .env file
+  await dotenv.load(fileName: ".env");
+
+  // Check if the required variables are set
+  final channelId = dotenv.env['CHANNEL_ID'];
+  final apiKey = dotenv.env['API_KEY'];
+
+  if (channelId == null || apiKey == null) {
+    throw Exception(
+        'The environment variables CHANNEL_ID and API_KEY are not set in the .env file.');
+  }
+
   runApp(const MyApp());
 }
 

--- a/thermal_app/lib/services/api_service.dart
+++ b/thermal_app/lib/services/api_service.dart
@@ -1,11 +1,11 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 class ApiService {
-  final String baseUrl;
-  final String apiKey;
-
-  ApiService({required this.baseUrl, required this.apiKey});
+  final String baseUrl =
+      'https://api.thingspeak.com/channels/${dotenv.env['CHANNEL_ID']}';
+  final String apiKey = dotenv.env['API_KEY']!;
 
   Future<Map<String, dynamic>> fetchLatestData() async {
     final response = await http

--- a/thermal_app/pubspec.lock
+++ b/thermal_app/pubspec.lock
@@ -62,6 +62,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      sha256: b7c7be5cd9f6ef7a78429cabd2774d3c4af50e79cb2b7593e3d5d763ef95c61b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/thermal_app/pubspec.yaml
+++ b/thermal_app/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   http: ^1.1.0
+  flutter_dotenv: ^5.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request introduces environment variable support to the `thermal_app` project, enabling secure management of sensitive configuration such as API keys and channel IDs. The changes ensure that these values are loaded from a `.env` file at runtime, improving both security and flexibility. Key updates include integrating the `flutter_dotenv` package, updating service initialization, and adding example environment files.

**Environment variable management:**

* Added a `.env.example` file with placeholders for `CHANNEL_ID` and `API_KEY` to guide developers on required environment variables.
* Updated `.gitignore` to exclude the `.env` file, ensuring sensitive data is not committed to version control.

**Codebase updates for dotenv integration:**

* Modified `main.dart` to load environment variables at startup and enforce the presence of `CHANNEL_ID` and `API_KEY`, throwing an exception if they are missing.
* Refactored `ApiService` in `api_service.dart` to read `CHANNEL_ID` and `API_KEY` from environment variables instead of constructor parameters.

**Dependency management:**

* Added `flutter_dotenv` to `pubspec.yaml` dependencies to support environment variable loading.