### PR TITLE
PJ-06: Add Home, Alerts, Config, and History screens with navigation

### DIFF
--- a/thermal_app/lib/main.dart
+++ b/thermal_app/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'screens/login_screen.dart';
+import 'screens/home_screen.dart';
 
 Future<void> main() async {
   try {
@@ -36,7 +36,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const LoginScreen(),
+      home: const HomeScreen(),
     );
   }
 }

--- a/thermal_app/lib/screens/alerts_screen.dart
+++ b/thermal_app/lib/screens/alerts_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+class AlertsScreen extends StatelessWidget {
+  const AlertsScreen({Key? key}) : super(key: key);
+
+  // Main build method for Alerts screen
+  @override
+  Widget build(BuildContext context) {
+    try {
+      return SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 24.0, horizontal: 0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              const Text(
+                'Alertas',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 16),
+              _CardContainer(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: const [
+                    _AlertRow('Temperatura acima de 30°C', 'Hoje, 14:32'),
+                    Divider(),
+                    _AlertRow('Sensor desconectado', 'Ontem, 18:10'),
+                    Divider(),
+                    _AlertRow('Temperatura abaixo de 15°C', 'Ontem, 07:45'),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    } catch (e, stack) {
+      debugPrint('Error in AlertsScreen: $e\n$stack');
+      return Center(child: Text('Error loading Alerts screen'));
+    }
+  }
+}
+
+class _CardContainer extends StatelessWidget {
+  final Widget child;
+  const _CardContainer({required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [BoxShadow(color: Colors.black12, blurRadius: 8)],
+      ),
+      child: child,
+    );
+  }
+}
+
+class _AlertRow extends StatelessWidget {
+  final String message;
+  final String time;
+  const _AlertRow(this.message, this.time);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.warning, color: Colors.red, size: 20),
+              const SizedBox(width: 8),
+              Text(message),
+            ],
+          ),
+          Text(time,
+              style: const TextStyle(color: Colors.black54, fontSize: 12)),
+        ],
+      ),
+    );
+  }
+}

--- a/thermal_app/lib/screens/config_screen.dart
+++ b/thermal_app/lib/screens/config_screen.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+
+class ConfigScreen extends StatelessWidget {
+  const ConfigScreen({Key? key}) : super(key: key);
+
+  // Main build method for Config screen
+  @override
+  Widget build(BuildContext context) {
+    try {
+      return SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 24.0, horizontal: 0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              const Text(
+                'Configurações',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 16),
+              _CardContainer(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('Preferências',
+                        style: TextStyle(fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 8),
+                    _FakeSwitchRow('Notificações Push'),
+                    _FakeSwitchRow('Modo Escuro'),
+                    _FakeSwitchRow('Sons de Alerta'),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              _CardContainer(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('Sensor',
+                        style: TextStyle(fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 8),
+                    _FakeInputRow('Intervalo de Leitura', '30 segundos'),
+                    _FakeInputRow('Calibração', '+0.0°C'),
+                    const SizedBox(height: 8),
+                    SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.black,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(8)),
+                        ),
+                        onPressed: () {},
+                        child: const Text('Testar Sensor'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              _CardContainer(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('Dados',
+                        style: TextStyle(fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 8),
+                    _FakeButtonRow(Icons.upload, 'Exportar Dados'),
+                    _FakeButtonRow(Icons.delete, 'Limpar Histórico'),
+                    _FakeButtonRow(Icons.cloud, 'Backup na Nuvem'),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    } catch (e, stack) {
+      debugPrint('Error in ConfigScreen: $e\n$stack');
+      return Center(child: Text('Error loading Config screen'));
+    }
+  }
+}
+
+class _CardContainer extends StatelessWidget {
+  final Widget child;
+  const _CardContainer({required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [BoxShadow(color: Colors.black12, blurRadius: 8)],
+      ),
+      child: child,
+    );
+  }
+}
+
+class _FakeSwitchRow extends StatelessWidget {
+  final String label;
+  const _FakeSwitchRow(this.label);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(label),
+          Switch(value: false, onChanged: null),
+        ],
+      ),
+    );
+  }
+}
+
+class _FakeInputRow extends StatelessWidget {
+  final String label;
+  final String value;
+  const _FakeInputRow(this.label, this.value);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label),
+          const SizedBox(height: 4),
+          TextField(
+            enabled: false,
+            decoration: InputDecoration(
+              hintText: value,
+              filled: true,
+              fillColor: Colors.grey[200],
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+                borderSide: BorderSide.none,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FakeButtonRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  const _FakeButtonRow(this.icon, this.label);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4.0),
+      child: SizedBox(
+        width: double.infinity,
+        child: ElevatedButton.icon(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.white,
+            foregroundColor: Colors.black,
+            elevation: 0,
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          ),
+          onPressed: () {},
+          icon: Icon(icon),
+          label: Text(label),
+        ),
+      ),
+    );
+  }
+}

--- a/thermal_app/lib/screens/history_screen.dart
+++ b/thermal_app/lib/screens/history_screen.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+
+class HistoryScreen extends StatelessWidget {
+  const HistoryScreen({Key? key}) : super(key: key);
+
+  // Main build method for History screen
+  @override
+  Widget build(BuildContext context) {
+    try {
+      return SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 24.0, horizontal: 0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              const Text(
+                'Histórico Completo',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 16),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  _TabButton('Hoje', true),
+                  _TabButton('Semana', false),
+                  _TabButton('Mês', false),
+                ],
+              ),
+              const SizedBox(height: 16),
+              _CardContainer(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('Média Semanal',
+                        style: TextStyle(fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 8),
+                    SizedBox(
+                      height: 130, // Increased height to prevent overflow
+                      child: Align(
+                        alignment: Alignment.bottomCenter,
+                        child: _FakeBarChart(),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              _CardContainer(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: const [
+                    Text('Estatísticas',
+                        style: TextStyle(fontWeight: FontWeight.bold)),
+                    SizedBox(height: 8),
+                    _StatRow('Temperatura Média', '24.8°C'),
+                    _StatRow('Máxima Registrada', '28.2°C'),
+                    _StatRow('Mínima Registrada', '18.5°C'),
+                    _StatRow('Leituras Hoje', '342'),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    } catch (e, stack) {
+      debugPrint('Error in HistoryScreen: $e\n$stack');
+      return Center(child: Text('Error loading History screen'));
+    }
+  }
+}
+
+class _TabButton extends StatelessWidget {
+  final String label;
+  final bool selected;
+  const _TabButton(this.label, this.selected);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4.0),
+      child: ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: selected ? Colors.black : Colors.white,
+          foregroundColor: selected ? Colors.white : Colors.black,
+          elevation: 0,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        ),
+        onPressed: () {},
+        child: Text(label),
+      ),
+    );
+  }
+}
+
+class _CardContainer extends StatelessWidget {
+  final Widget child;
+  const _CardContainer({required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [BoxShadow(color: Colors.black12, blurRadius: 8)],
+      ),
+      child: child,
+    );
+  }
+}
+
+// Widget for fake bar chart in History screen
+class _FakeBarChart extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final List<double> values = [23, 24, 23, 25, 24, 23, 24];
+    final List<String> labels = [
+      'Seg',
+      'Ter',
+      'Qua',
+      'Qui',
+      'Sex',
+      'Sáb',
+      'Dom'
+    ];
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: List.generate(values.length, (i) {
+        return Expanded(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              Container(
+                height: values[i] * 4,
+                width: 16,
+                decoration: BoxDecoration(
+                  color: Color(0xFF3A8DFF),
+                  borderRadius: BorderRadius.circular(4),
+                ),
+              ),
+              const SizedBox(height: 4),
+              FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(labels[i], style: const TextStyle(fontSize: 12)),
+              ),
+            ],
+          ),
+        );
+      }),
+    );
+  }
+}
+
+class _StatRow extends StatelessWidget {
+  final String label;
+  final String value;
+  const _StatRow(this.label, this.value);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(label),
+          Text(value, style: const TextStyle(fontWeight: FontWeight.bold)),
+        ],
+      ),
+    );
+  }
+}

--- a/thermal_app/lib/screens/home_screen.dart
+++ b/thermal_app/lib/screens/home_screen.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'dashboard_screen.dart';
+import 'history_screen.dart';
+import 'alerts_screen.dart';
+import 'config_screen.dart';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({Key? key}) : super(key: key);
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  int _selectedIndex = 0;
+
+  // List of screens for navigation
+  final List<Widget> _screens = [
+    const DashboardScreen(),
+    const HistoryScreen(),
+    const AlertsScreen(),
+    const ConfigScreen(),
+  ];
+
+  // Handle navigation bar tap
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+      debugPrint('Switched to tab: $_selectedIndex');
+    });
+  }
+
+  // Main build method for HomeScreen
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF5F6F8),
+      body: SafeArea(child: _screens[_selectedIndex]),
+      bottomNavigationBar: BottomNavigationBar(
+        type: BottomNavigationBarType.fixed,
+        backgroundColor: Colors.white,
+        selectedItemColor: Colors.black,
+        unselectedItemColor: Colors.black54,
+        currentIndex: _selectedIndex,
+        onTap: _onItemTapped,
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.home),
+            label: 'Home',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.bar_chart),
+            label: 'Histórico',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.warning),
+            label: 'Alertas',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.settings),
+            label: 'Config',
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This pull request introduces a new main navigation structure for the app, replacing the previous login-based entry point with a multi-tabbed home screen. It adds three new screens—History, Alerts, and Config—alongside the existing Dashboard, and wires them together using a bottom navigation bar. Each screen includes its own UI and layout.

**Navigation and App Structure**

* Replaces the initial route from `LoginScreen` to `HomeScreen` in `main.dart`, making the multi-tab home screen the app's entry point. [[1]](diffhunk://#diff-8d7ed9afbb1b1d6d435f26fdf66279c348d92f1375375f13fdbe85a2694cfe5dL3-R3) [[2]](diffhunk://#diff-8d7ed9afbb1b1d6d435f26fdf66279c348d92f1375375f13fdbe85a2694cfe5dL39-R39)
* Implements the new `HomeScreen` widget with a bottom navigation bar, allowing users to switch between Dashboard, History, Alerts, and Config screens.

**New Screens and UI Components**

* Adds `HistoryScreen` with tab buttons, a fake bar chart, and statistics display for temperature readings.
* Adds `AlertsScreen` displaying a list of recent alerts in a card layout.
* Adds `ConfigScreen` with sections for preferences, sensor settings, and data management, using various input and button components.