### PR TITLE
PJ-07: Refactor navigation: Update main app entry to use LoginScreen …

### DIFF
--- a/thermal_app/lib/main.dart
+++ b/thermal_app/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'screens/home_screen.dart';
+import 'screens/login_screen.dart';
 
 Future<void> main() async {
   try {
@@ -36,7 +36,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const HomeScreen(),
+      home: const LoginScreen(),
     );
   }
 }

--- a/thermal_app/lib/screens/login_screen.dart
+++ b/thermal_app/lib/screens/login_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'dashboard_screen.dart';
+import 'home_screen.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({Key? key}) : super(key: key);
@@ -15,7 +15,7 @@ class _LoginScreenState extends State<LoginScreen> {
   void _login() {
     Navigator.pushReplacement(
       context,
-      MaterialPageRoute(builder: (context) => const DashboardScreen()),
+      MaterialPageRoute(builder: (context) => const HomeScreen()),
     );
   }
 


### PR DESCRIPTION
This pull request updates the app's initial screen flow by replacing the default landing page with a login screen and adjusts navigation after login to direct users to the home screen instead of the dashboard. These changes help enforce authentication before accessing the main content.

**Screen flow changes:**

* The app now launches with `LoginScreen` instead of `HomeScreen` in `main.dart`. [[1]](diffhunk://#diff-8d7ed9afbb1b1d6d435f26fdf66279c348d92f1375375f13fdbe85a2694cfe5dL3-R3) [[2]](diffhunk://#diff-8d7ed9afbb1b1d6d435f26fdf66279c348d92f1375375f13fdbe85a2694cfe5dL39-R39)
* After a successful login, navigation goes to `HomeScreen` instead of `DashboardScreen` in `login_screen.dart`. [[1]](diffhunk://#diff-7938dcb5c0dd85ea96e417bf225cc30533bcef7afe5bede9fc268947a1e62b31L2-R2) [[2]](diffhunk://#diff-7938dcb5c0dd85ea96e417bf225cc30533bcef7afe5bede9fc268947a1e62b31L18-R18)…and adjust login flow to navigate to HomeScreen